### PR TITLE
README visibility Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The clementine-project is also for exploring the mechanisms and libs of mycroft 
 - From terminal: cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
 - From terminal: cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
 
-#### For other distributions:
+##### For other distributions:
 - Python Dbus and Python Psutil package is required and copying the Python Dbus folder and lib from your system python install over to /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/.
 
 ##### How To Use: 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The clementine-project is also for exploring the mechanisms and libs of mycroft 
 - From terminal: cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
 - From terminal: cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
 
-* For other distributions:
+#### For other distributions:
 - Python Dbus and Python Psutil package is required and copying the Python Dbus folder and lib from your system python install over to /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/.
 
 ##### How To Use: 


### PR DESCRIPTION
When going through the readme, the section for other distributions was hidden under the another section. I simply made this it's own section.